### PR TITLE
add node server repo to this repo as submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "support/server"]
+	path = support/server
+	url = ssh://git@pentagon7.byu.edu:7999/id/university-api-documentation-sandbox.git


### PR DESCRIPTION
Adds the node server that reads the mapping and serves the json docs as a submodule so that others can easily edit. No reason this shouldn't also be open source.

You will need to run `git submodule update --init` from the main `api-repo-sandbox` repository in order to pull down the submodule code. You will also need to make sure you have your ssh key on our Atlassian Stash instance.

Would need someone that is a member of this github org to merge this in if they want. (such as @windley  or @djwalker5 or @mhailstone).